### PR TITLE
setDTthreads in on.exit()

### DIFF
--- a/R/APA.R
+++ b/R/APA.R
@@ -137,6 +137,7 @@ APA <- function(experiment, loop.bed, smallTreshold = NULL, rmOutlier = T,
   pos.list <- data.frame(x = x.pos, y = y.pos) %>% split(., seq(nrow(.))) 
   
   old_threads <- getDTthreads()
+  on.exit(setDTthreads(old_threads))
   setDTthreads(1)
   
   rawMatArray <- vapply(pos.list, FUN.VALUE = matrix(NA_real_, nrow = size, ncol = size), FUN = function(pos){
@@ -156,8 +157,7 @@ APA <- function(experiment, loop.bed, smallTreshold = NULL, rmOutlier = T,
     return(hic.mat)
     
   })
-  
-  setDTthreads(old_threads)
+ 
   
   rawMatList <- lapply(seq(dim(rawMatArray)[3]), function(x) rawMatArray[ , , x])
 


### PR DESCRIPTION
Moving the `setDTthreads()` after the loop to reset the default data.table threads in an `on.exit()`. This would be preferable/safer because it is always executed on function exit, even when an error occurs.