### PR TITLE
Added a clean-up function for centromeres.

### DIFF
--- a/R/construct.experiment.R
+++ b/R/construct.experiment.R
@@ -37,7 +37,7 @@ construct.experiment <- function(signalPath, indicesPath, name, ignore.checks = 
   res = as.numeric( median(ABS$V3-ABS$V2)  )
 
   if(!is.null(centromeres)){
-    colnames(centromeres)[1:3] <- paste0('V',1:3)
+    centromeres <- clean_centromeres(centromeres, res)
   }
 
   # check is all chromosomes have actual data
@@ -95,4 +95,45 @@ construct.experiment <- function(signalPath, indicesPath, name, ignore.checks = 
     RMCHROM = RMCHROM
 
   )
+}
+
+clean_centromeres <- function(centros, resolution) {
+  # Essentially does the same as `reduce(a_granges_object, min.gapwidth = resolution)
+  
+  centros <- as.data.frame(centros)
+  
+  # Drop unused factor levels
+  if (is.factor(centros[,1])) {
+    centros[,1] <- droplevels(centros[,1])
+  }
+  
+  # Set column names and order on chromosome and start
+  centros <- setNames(centros, paste0("V", 1:3)) 
+  centros <- centros[order(centros[,1], centros[,2]),]
+  
+  # Test wether adjacent entries should be merged
+  centros$merge <- c(FALSE, vapply(seq_len(nrow(centros) - 1), function(i){
+    
+    # Is the difference between end and next start sub-resolution?
+    test <- abs(centros[i, 3] - centros[i + 1, 2]) < resolution
+    
+    # Are the entries on the same chromosome?
+    test && centros[i, 1] == centros[i + 1, 1]
+
+  }, logical(1)))
+  
+  # Merge the TRUE entries
+  while (any(centros$merge)) {
+    # What is the next entry to be merged?
+    i <- which(centros$merge)[1]
+    
+    # Replace end of previous entry with end of current entry
+    centros[i - 1, 3] <- centros[i, 3]
+    
+    # Remove current entry
+    centros <- centros[-i,]
+  }
+  
+  # Return centromeres
+  centros[,1:3]
 }


### PR DESCRIPTION
For genomes with non-acrocenric chromosomes (e.g. hg19, hg38), trying to derive centromeric locations from the cytobands file downloaded from the UCSC table browser could be attempted in the following way:

```
cytobands <- read.table("some_path/cytobands.txt", header = T, sep = "\t")
centromeres <- cytobands[cytobands$gieStain == "acen",]
```

Which sounds reasonable, but yields a data.frame of the following format (for hg38):

```
head(centromeres)
```
```
    chrom chromStart  chromEnd  name gieStain
34   chr1  121700000 123400000 p11.1     acen
35   chr1  123400000 125100000   q11     acen
87   chr2   91800000  93900000 p11.1     acen
88   chr2   93900000  96000000 q11.1     acen
152  chr3   87800000  90900000 p11.1     acen
153  chr3   90900000  94000000 q11.1     acen
```

Wherein each centromeres occupies two rows. While GENOVA accepts this format, this can cause errors and warnings in downstream analysis (in calculating relative contact probabilities, HiC Seg TAD calling, possibly others). The proposed change is to use a centromere cleaning function used in the experiment constructor, which collapses multi-row centromeres into single-row centromeres when the distance between end and start of the multi-row centromere is below the Hi-C matrix resolution.